### PR TITLE
Create H1 component

### DIFF
--- a/green-foods/src/components/typography/H1/H1.js
+++ b/green-foods/src/components/typography/H1/H1.js
@@ -1,0 +1,5 @@
+const H1 = ({ title }) => {
+  return <h1>{title}</h1>;
+};
+
+export default H1;

--- a/green-foods/src/components/typography/H1/H1.test.js
+++ b/green-foods/src/components/typography/H1/H1.test.js
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import H1 from './H1';
+
+describe('H1', () => {
+  test('it renders', () => {
+    render(<H1 title='I am a H1 component' />);
+    const h1 = screen.getByText('I am a H1 component');
+
+    expect(h1).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Summary:
I created a H1 component that can be reused in the app. It takes in a `title` prop, which allows the title to be displayed and also has a test to check if the component renders. Although there is currently no design, I believe preparing for when there is will make for an easier switch.

To-do:
There is no design as of yet, but when there is we can style this component. This would probably be through a `H1.css` stylesheet or a React JSS styles object. We should probably also allow the component to have custom styles by adding a `customStyles` prop.