### PR TITLE
Create P component

### DIFF
--- a/green-foods/src/components/typography/P/P.js
+++ b/green-foods/src/components/typography/P/P.js
@@ -1,0 +1,10 @@
+const P = ({ children, text }) => {
+  return (
+    <p>
+      {text}
+      {children}
+    </p>
+  );
+};
+
+export default P;

--- a/green-foods/src/components/typography/P/P.test.js
+++ b/green-foods/src/components/typography/P/P.test.js
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import P from './P';
+
+describe('P', () => {
+  test('it renders', () => {
+    render(<P text='I am a P component and this is some text.' />);
+    const p = screen.getByText('I am a P component and this is some text.');
+
+    expect(p).toBeInTheDocument();
+  });
+
+  test('it can accept children elements', () => {
+    render(
+      <P text='I am a P component and this is some text.'>
+        <small>This is some random small text</small>
+      </P>
+    );
+    const child = screen.getByText('This is some random small text');
+
+    expect(child).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Summary:
I created a P component that can be reused in the app. It takes in `text` and `children` props, which allows the text to be displayed and have things nested in it just in case. There are also has test to check if the component renders and can accept a child.

To-do:
Similar to the `H1` component, this one needs to be styled as well.